### PR TITLE
Add CUDA 10.1, specific links for Python3 version of packages, added …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
+FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
 
 # Core Linux Deps
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --fix-missing --no-install-recommends \
@@ -14,9 +14,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --fix-mi
 	libxmu-dev \
 	gfortran \
         pkg-config \
-	python-numpy \
-	python-dev \
-	python-setuptools \
+	python3-numpy \
+	python3-dev \
+	python3-setuptools \
 	libboost-python-dev \
 	libboost-thread-dev \
         pbzip2 \
@@ -55,9 +55,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --fix-mi
 
 # Install TensorRT (TPU Access)
 RUN apt-get update && \
-        apt-get install nvinfer-runtime-trt-repo-ubuntu1804-5.0.2-ga-cuda10.0 && \
+        apt-get install nvinfer-runtime-trt-repo-ubuntu1804-5.0.2-ga-cuda10.0 -y && \
         apt-get update && \
-        apt-get install libnvinfer5=5.0.2-1+cuda10.0
+        apt-get install libnvinfer5=5.0.2-1+cuda10.0 -y
 
 RUN file="$(ls -1 /usr/local/)" && echo $file
 


### PR DESCRIPTION
…"-y" top apt-get install for TensorRT

Added Python3 specific versions of packages. Set core base container CUDA version to 10.1 and added "-y" to TensorRT "apt-get" installation as it was failing on unattended install. Tested 24 July 2019 on GV100 GPU.